### PR TITLE
Allow execution of javascript <script> tags inside of dynamically loaded HTMLBox content

### DIFF
--- a/lino/modlib/extjs/linoweb.js
+++ b/lino/modlib/extjs/linoweb.js
@@ -2536,7 +2536,7 @@ Lino.HtmlBoxPanel = Ext.extend(Lino.HtmlBoxPanel,{
         this.set_base_params(this.containing_panel.get_master_params());
         var el = box.getEl();
         if (el) {
-          el.update(record ? this.format_data(record.data[this.name]) : '');
+          el.update(record ? this.format_data(record.data[this.name]) : '', true);
           //~ console.log('20130723 HtmlBox.refresh()',this.name);
         //~ } else {
           //~ console.log('HtmlBox.refresh() failed for',this.name);


### PR DESCRIPTION
Simple change to allow HTML box to use some javascript. I use it for adding Ext.Resizer to textareas to allow dynamic resizing.
