### PR TITLE
Fix exception when printing unicode characters

### DIFF
--- a/lino/modlib/print_pisa/models.py
+++ b/lino/modlib/print_pisa/models.py
@@ -41,7 +41,7 @@ class PrintTableActionPisa(PrintTableAction):
         extend_context(context)
 
         template = settings.SITE.jinja_env.get_template(self.template_name)
-        html = template.render(**context)
+        html = template.render(**context).encode('utf-8')
 
         with open(output_file + '.html', "w") as file:
             file.write(html)


### PR DESCRIPTION
Small fix. Sometimes during "Export table to PDF" action my customers experienced Unicode error. This fixed it.

`template.render(**context)` usually returns utf-8 encoded string, but not every time. So this conversion makes sure it is utf-8.
